### PR TITLE
Add preferences

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ fi
 
 
 rm -f zotero-ocr-${version}.xpi
-zip -r zotero-ocr-${version}.xpi chrome/* chrome.manifest install.rdf
+zip -r zotero-ocr-${version}.xpi chrome/* defaults/* chrome.manifest install.rdf

--- a/chrome/content/overlay.xul
+++ b/chrome/content/overlay.xul
@@ -25,4 +25,8 @@
           />
     </popup>
 
+    <menupopup id="menu_ToolsPopup">
+      <menuitem id="zoteroocr-options" insertafter="menu_preferences" label="&ocr.preferences.label;" oncommand="Zotero.OCR.openPreferenceWindow();"/>
+    </menupopup>
+
 </overlay>

--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -3,9 +3,11 @@
 <!DOCTYPE prefwindow SYSTEM "chrome://zoteroocr/locale/zoteroocr.dtd">
 
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero-platform/content/preferences.css"?>
 
 <prefwindow 
     id="zoteroocr-preferences"
+    title="Zotero OCR Preferences"
     xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
     <script src="chrome://zotero/content/include.js"/>
@@ -17,7 +19,7 @@
             src="chrome://zoteroocr/locale/zoteroocr.properties"/>
     </stringbundleset>
 
-    <prefpane label="General" id="zoteroocr-prefpane-general" flex="1" position="1">
+    <prefpane label="General" id="zoteroocr-prefpane-general" flex="1">
         <preferences>
             <preference id="pref-zoteroocr-ocrPath" name="extensions.zotero.zoteroocr.ocrPath" type="string"/>
         </preferences>

--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -4,6 +4,8 @@
 
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://zotero-platform/content/preferences.css"?>
+<?xml-stylesheet href="chrome://browser/skin/preferences/preferences.css"?>
+<?xml-stylesheet href="chrome://zotero/skin/preferences.css"?>
 
 <prefwindow 
     id="zoteroocr-preferences"
@@ -22,11 +24,29 @@
     <prefpane label="General" id="zoteroocr-prefpane-general" flex="1">
         <preferences>
             <preference id="pref-zoteroocr-ocrPath" name="extensions.zotero.zoteroocr.ocrPath" type="string"/>
+            <preference id="pref-zoteroocr-language" name="extensions.zotero.zoteroocr.language" type="string"/>
+            <preference id="pref-zoteroocr-output-note" name="extensions.zotero.zoteroocr.outputNote" type="bool"/>
+            <preference id="pref-zoteroocr-output-pdf" name="extensions.zotero.zoteroocr.outputPDF" type="bool"/>
+            <preference id="pref-zoteroocr-overwrite-pdf" name="extensions.zotero.zoteroocr.overwritePDF" type="bool"/>
+            <preference id="pref-zoteroocr-output-hocr" name="extensions.zotero.zoteroocr.outputHocr" type="bool"/>
+            <preference id="pref-zoteroocr-output-png" name="extensions.zotero.zoteroocr.outputPNG" type="bool"/>
         </preferences>
         <groupbox>
-            <caption label="OCR path"/>
+            <caption label="OCR parameters"/>
             <label value="You can indicate here the path to your OCR engine:"/>
             <textbox id="pref-zoteroocr-ocrPath-value" flex="1" preference="pref-zoteroocr-ocrPath"/>
+            <hbox>
+                <label value="Choose a language/script you want to use for recognition (default is eng):"/>
+                <textbox id="pref-zoteroocr-language-value" preference="pref-zoteroocr-language" width="100"/>
+            </hbox>
+        </groupbox>
+        <groupbox>
+            <caption label="Output options"/>
+            <checkbox preference="pref-zoteroocr-output-note" label="Save output as a note"/>
+            <checkbox id="checkbox-zoteroocr-output-pdf" preference="pref-zoteroocr-output-pdf" label="Save output as a PDF with text layer" oncommand="Zotero.OCR.updatePDFOverwritePref()"/>
+            <checkbox id="checkbox-zoteroocr-overwrite-pdf" preference="pref-zoteroocr-overwrite-pdf" label="Overwrite the initial PDF with the output" class="indented-pref"/>
+            <checkbox preference="pref-zoteroocr-output-hocr" label="Save output as a HTML/hocr file"/>
+            <checkbox preference="pref-zoteroocr-output-png" label="Save the intermediate PNGs as well in the folder"/>
         </groupbox>
     </prefpane>
 

--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -13,7 +13,6 @@
     xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
     <script src="chrome://zotero/content/include.js"/>
-    <script src="chrome://zoteroocr/content/zoteroocr.js"/>
 
     <stringbundleset id="stringbundleset">
         <stringbundle

--- a/chrome/content/zoteroocr.js
+++ b/chrome/content/zoteroocr.js
@@ -105,7 +105,7 @@ Zotero.OCR = new function() {
 			let base = pdf.replace(/\.pdf$/, '');
 			let dir = OS.Path.dirname(pdf);
 			let infofile = base + '.info.txt';
-			let ocrbase = base + '.ocr';
+			let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? base : base + '.ocr';
 			// TODO filter out PDFs which have already a text layer
 
 			// extract images from PDF
@@ -133,12 +133,7 @@ Zotero.OCR = new function() {
 
 			let parameters = [dir + '/image-list.txt'];
 			let requestedFormats = [];
-			if (Zotero.Prefs.get("zoteroocr.overwritePDF")) {
-				parameters.push(base);
-			}
-			else {
-				parameters.push(ocrbase);
-			}
+			parameters.push(ocrbase);
 			if (Zotero.Prefs.get("zoteroocr.language")) {
 				parameters.push('-l');
 				parameters.push(Zotero.Prefs.get("zoteroocr.language"));
@@ -177,6 +172,8 @@ Zotero.OCR = new function() {
 			}
 			
 			if (!Zotero.Prefs.get("zoteroocr.outputPNG") && imageListArray) {
+				// delete image list
+				yield Zotero.File.removeIfExists(imageList);
 				// delete PNGs
 				for (let imageName of imageListArray) {
 					yield Zotero.File.removeIfExists(imageName);

--- a/chrome/content/zoteroocr.js
+++ b/chrome/content/zoteroocr.js
@@ -6,6 +6,14 @@ Components.utils.import("resource://gre/modules/osfile.jsm");
 
 Zotero.OCR = new function() {
 
+	this.openPreferenceWindow = function(paneID, action) {
+		var io = {pane: paneID, action: action};
+		window.openDialog('chrome://zoteroocr/content/preferences.xul',
+				'Zotero OCR Preferences',
+				'chrome,titlebar,toolbar,centerscreen' + Zotero.Prefs.get('browser.preferences.instantApply', true) ? 'dialog=no' : 'modal', io
+		);
+	};
+
 	this.recognize = Zotero.Promise.coroutine(function* () {
 
 		// Look for the tesseract executable in the settings and at commonly used locations.

--- a/chrome/content/zoteroocr.js
+++ b/chrome/content/zoteroocr.js
@@ -8,7 +8,9 @@ Zotero.OCR = new function() {
 
 	this.openPreferenceWindow = function(paneID, action) {
 		var io = {pane: paneID, action: action};
-		window.openDialog('chrome://zoteroocr/content/preferences.xul',
+		
+		window.openDialog(
+				'chrome://zoteroocr/content/preferences.xul',
 				'Zotero OCR Preferences',
 				'chrome,titlebar,toolbar,centerscreen' + Zotero.Prefs.get('browser.preferences.instantApply', true) ? 'dialog=no' : 'modal', io
 		);

--- a/chrome/locale/en-US/zoteroocr.dtd
+++ b/chrome/locale/en-US/zoteroocr.dtd
@@ -1,1 +1,2 @@
 <!ENTITY ocr.menu.label			"OCR selected PDF(s)">
+<!ENTITY ocr.preferences.label			"Zotero OCR Preferences">

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,0 +1,6 @@
+// don't set ocrPath, language by default
+pref("extensions.zotero.zoteroocr.outputNote", true);
+pref("extensions.zotero.zoteroocr.outputPDF", true);
+pref("extensions.zotero.zoteroocr.overwritePDF", false);
+pref("extensions.zotero.zoteroocr.outputHocr", true);
+pref("extensions.zotero.zoteroocr.outputPNG", true);


### PR DESCRIPTION
This solves #9 and also give an simple option for indicating another language as in #8.

However, the current behavior is very strange: The first time one can click on the "Zotero OCR Preferences" in the Tools menu and everything works find. But one cannot open the preferences a second time, there is an error showing up
```
[JavaScript Error: "NS_ERROR_NOT_AVAILABLE: " {file: "chrome://zoteroocr/content/zoteroocr.js" line: 11}]
Zotero.OCR</this.openPreferenceWindow@chrome://zoteroocr/content/zoteroocr.js:11:3
oncommand@chrome://zotero/content/standalone/standalone.xul:1:1
```
@dstillman: Have you any idea what this error message means exactly?

Moreover, we maybe want to give some default values to the preferences as long as they are not set differently. I have to check how this is usually done.