### PR TITLE
Add option to set pdftoppm path

### DIFF
--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -23,6 +23,7 @@
     <prefpane label="General" id="zoteroocr-prefpane-general" flex="1">
         <preferences>
             <preference id="pref-zoteroocr-ocrPath" name="extensions.zotero.zoteroocr.ocrPath" type="string"/>
+            <preference id="pref-zoteroocr-pdftoppmPath" name="extensions.zotero.zoteroocr.pdftoppmPath" type="string"/>
             <preference id="pref-zoteroocr-language" name="extensions.zotero.zoteroocr.language" type="string"/>
             <preference id="pref-zoteroocr-output-note" name="extensions.zotero.zoteroocr.outputNote" type="bool"/>
             <preference id="pref-zoteroocr-output-pdf" name="extensions.zotero.zoteroocr.outputPDF" type="bool"/>
@@ -34,6 +35,8 @@
             <caption label="OCR parameters"/>
             <label value="You can indicate here the path to your OCR engine:"/>
             <textbox id="pref-zoteroocr-ocrPath-value" flex="1" preference="pref-zoteroocr-ocrPath"/>
+            <label value="You can indicate here the path to pdftoppm:"/>
+            <textbox id="pref-zoteroocr-pdftoppmPath-value" flex="1" preference="pref-zoteroocr-pdftoppmPath"/>
             <hbox>
                 <label value="Choose a language/script you want to use for recognition (default is eng):"/>
                 <textbox id="pref-zoteroocr-language-value" preference="pref-zoteroocr-language" width="100"/>

--- a/chrome/content/zoteroocr.js
+++ b/chrome/content/zoteroocr.js
@@ -73,8 +73,11 @@ Zotero.OCR = new function() {
 			return;
 		}
 		if (!(yield OS.File.exists(pdftoppm))) {
-			alert("No " + pdftoppm + " executable found.");
-			return;
+                        pdftoppm = Zotero.Prefs.get("zoteroocr.pdftoppmPath");
+                        if (!(yield OS.File.exists(pdftoppm))) {
+				alert("No " + pdftoppm + " executable found.");
+				return;
+			}
 		}
 
 		let items = Zotero.getActiveZoteroPane().getSelectedItems();

--- a/chrome/content/zoteroocr.js
+++ b/chrome/content/zoteroocr.js
@@ -53,31 +53,35 @@ Zotero.OCR = new function() {
 			return;
 		}
 
-		// Look for pdfinfo and pdftoppm in the same directory as the zotero executable.
-		// Abort with an alert if they are not found.
+		// Use the special pdfinfo variant in the zotero directory (which comes along Zotero)
 		// See https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/File_I_O#Getting_special_files
 		// and https://dxr.mozilla.org/mozilla-central/source/xpcom/io/nsDirectoryServiceDefs.h.
 		let dir = FileUtils.getDir('GreBinD', []);
 		let pdfinfo = dir.clone();
 		pdfinfo.append("pdfinfo");
 		pdfinfo = pdfinfo.path;
-		let pdftoppm = dir.clone();
-		pdftoppm.append("pdftoppm");
-		pdftoppm = pdftoppm.path;
 		if (Zotero.isWin) {
 			pdfinfo = pdfinfo + ".exe";
-			pdftoppm = pdftoppm + ".exe";
 		}
 		if (!(yield OS.File.exists(pdfinfo))) {
 			alert("No " + pdfinfo + " executable found.");
 			return;
 		}
+
+		// Look for a specific path in the preferences for pdftoppm
+		let pdftoppm = Zotero.Prefs.get("zoteroocr.pdftoppmPath");
+		if (!pdftoppm) {
+			// alternatively use the also the Zotero directory to look for pdftoppm
+			pdftoppm = dir.clone();
+			pdftoppm.append("pdftoppm");
+			pdftoppm = pdftoppm.path;
+		}
+		if (Zotero.isWin && !(pdftoppm.endsWith(".exe"))) {
+			pdftoppm = pdftoppm + ".exe";
+		}
 		if (!(yield OS.File.exists(pdftoppm))) {
-                        pdftoppm = Zotero.Prefs.get("zoteroocr.pdftoppmPath");
-                        if (!(yield OS.File.exists(pdftoppm))) {
-				alert("No " + pdftoppm + " executable found.");
-				return;
-			}
+			alert("No " + pdftoppm + " executable found.");
+			return;
 		}
 
 		let items = Zotero.getActiveZoteroPane().getSelectedItems();


### PR DESCRIPTION
This commit fixes #16 and fixes #14 by giving the option to set an explicit path to `pdftoppm`. 
Being able to set this path manually is:
 - easier for technically inadvanced users (See https://github.com/UB-Mannheim/zotero-ocr/issues/16#issuecomment-716051238)
 - Allows the usage of this addon when moving `pdftoppm` to the zotero binary directory is not suitable