### PR TITLE
Add configs for DPI, Page Segmentation Mode, and Zotero non-linked attachments

### DIFF
--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -31,6 +31,9 @@
             <preference id="pref-zoteroocr-output-hocr" name="extensions.zotero.zoteroocr.outputHocr" type="bool"/>
             <preference id="pref-zoteroocr-max-html-pages" name="extensions.zotero.zoteroocr.maximumPagesAsHtml" type="string"/>
             <preference id="pref-zoteroocr-output-png" name="extensions.zotero.zoteroocr.outputPNG" type="bool"/>
+            <preference id="pref-zoteroocr-output-dpi" name="extensions.zotero.zoteroocr.outputDPI" type="string"/>
+            <preference id="pref-zoteroocr-psm-mode" name="extensions.zotero.zoteroocr.outputPSMMode" type="string"/>
+            <preference id="pref-zoteroocr-output-as-copy-attachment" name="extensions.zotero.zoteroocr.outputAsCopyAttachment" type="bool"/>
         </preferences>
         <groupbox>
             <caption label="OCR parameters"/>
@@ -42,6 +45,14 @@
                 <label value="Choose a language/script you want to use for recognition (default is eng):"/>
                 <textbox id="pref-zoteroocr-language-value" preference="pref-zoteroocr-language" width="100"/>
             </hbox>
+            <hbox>
+                <label value="Output pdf dpi (default is 300):"/>
+                <textbox id="pref-zoteroocr-output-dpi-value" preference="pref-zoteroocr-output-dpi" width="100"/>
+            </hbox>
+            <hbox>
+                <label value="Tesseract Page Segmentation Mode - integer from 0 to 13 (inclusive)"/>
+                <textbox id="pref-zoteroocr-psm-mode-value" preference="pref-zoteroocr-psm-mode" width="70"/>
+            </hbox>
         </groupbox>
         <groupbox>
             <caption label="Output options"/>
@@ -52,9 +63,10 @@
             <!-- The next preference variable is actually a number, but we treat it as a string to avoid a special treatment with javascript here -->
             <hbox class="indented-pref">
               <label value="Maximum number of pages for which an individual HTML attachment is created:"/>
-              <textbox id="pref-zoteroocr-max-html-pages" preference="pref-zoteroocr-max-html-pages" width="20"/>
+              <textbox id="pref-zoteroocr-max-html-pages" preference="pref-zoteroocr-max-html-pages" width="40"/>
             </hbox>
             <checkbox preference="pref-zoteroocr-output-png" label="Save the intermediate PNGs as well in the folder"/>
+            <checkbox preference="pref-zoteroocr-output-as-copy-attachment" label="Import the resulting PDF as a copy instead of as a file link"/>
         </groupbox>
     </prefpane>
 

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -6,5 +6,5 @@ pref("extensions.zotero.zoteroocr.outputHocr", true);
 pref("extensions.zotero.zoteroocr.outputPNG", true);
 pref("extensions.zotero.zoteroocr.maximumPagesAsHtml", "5");
 pref("extensions.zotero.zoteroocr.outputDPI", "300");
-pref("extensions.zotero.zoteroocr.PSMMode", "1");
+pref("extensions.zotero.zoteroocr.PSMMode", "3");
 pref("extensions.zotero.zoteroocr.outputAsCopyAttachment", true);

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -5,3 +5,6 @@ pref("extensions.zotero.zoteroocr.overwritePDF", false);
 pref("extensions.zotero.zoteroocr.outputHocr", true);
 pref("extensions.zotero.zoteroocr.outputPNG", true);
 pref("extensions.zotero.zoteroocr.maximumPagesAsHtml", "5");
+pref("extensions.zotero.zoteroocr.outputDPI", "300");
+pref("extensions.zotero.zoteroocr.PSMMode", "1");
+pref("extensions.zotero.zoteroocr.outputAsCopyAttachment", true);


### PR DESCRIPTION
Thought I'd take a stab at this.

Added outputDPI and outputAsCopyAttachment as configuration options.

It seems to work, but I'm unable to get it to work with group libraries - do you have any idea why that might be?
briefly:

It works when I have a pdf selected on my personal 'My library' sub-collection, but when I use it on something selected in a sub-collection in my 'group library' I get errors like (below).  The errors happen with the zotero-ocr plugin as well so maybe I shouldn't be basing my logic off that plugin and that's my problem.

[JavaScript Error: "Parent item 1/4Q5DY97J not found" {file: "chrome://zotero/content/xpcom/data/item.js" line: 1537}]

My guess is that for some reason in group libraries parents are mangled in the database, but I'm not sure how to check or confirm.
because the code to me appears correct and this line 
https://github.com/danpf/zotero-ocr/blob/9eb9a8ec9a5ada40be27d07ca6de847637c14d2b/chrome/content/zoteroocr.js#L105 seems to be returning the right stuff.


I made a post in zotero dev about the issue but didn't get a response:
https://groups.google.com/g/zotero-dev/c/LVmcjIMqYvA