### PR TITLE
Reduce size of xpi file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@ if [ -z "$version" ]; then
 fi
 
 mkdir -p build
-(cd src && zip -r ../build/zotero-ocr-${version}.xpi * -x ".*")
+(cd src && zip -DX -r ../build/zotero-ocr-${version}.xpi * -x ".*")


### PR DESCRIPTION
Don't include directory and UNIX file attribute information when zipping. That information is not needed.

This reduces the size of the resulting xpi file.