### PR TITLE
CI: Add permissions to GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build Zotero OCR plugin
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This hopefully fixes a CI security issue which was reported by GitHub.