### PR TITLE
align image and imagelist names with PDF

### DIFF
--- a/src/chrome/content/zoteroocr.js
+++ b/src/chrome/content/zoteroocr.js
@@ -275,7 +275,6 @@ Zotero.OCR = new function() {
                     }
 
                     // save the list of images in a separate file
-                    // TODO 2025-11-27 adapt to new image filenames
                     let info = yield Zotero.File.getContentsAsync(infofile);
                     let numPages = info.match('Pages:[^0-9]+([0-9]+)')[1];
                     var imageListArray = [];
@@ -417,7 +416,7 @@ Zotero.OCR = new function() {
                         upperLimit = maximumPagesAsHtml + 1;
                     }
                     for (let i = 1; i < upperLimit; i++) {
-                        let pagename = 'page-' + i + '.html';
+                        let pagename = basename + '-page-' + i + '.html';
                         let htmlfile = Zotero.File.pathToFile(OS.Path.join(dir, pagename));
                         let pagecontent = preamble + "<div class='ocr_page'" + parts[i] + '<script src="https://unpkg.com/hocrjs"></script>\n</body>\n</html>';
                         Zotero.File.putContents(htmlfile, pagecontent);

--- a/src/zotero-ocr.js
+++ b/src/zotero-ocr.js
@@ -321,15 +321,15 @@ ZoteroOCR = {
 
                     await IOUtils.getChildren(dir).then(
                         (entries) => {
+                            let imgRegexp;
+                            if (imageFormat == "jpg") {
+                                imgRegexp = new RegExp(basename + "-page-\\d+\\.jpg$");
+                            } else {
+                                imgRegexp = new RegExp(basename + "-page-\\d+\\.png$");
+                            }
                             for (const entry of entries) {
-                                if (imageFormat == "jpg") {
-                                    if (entry.match(/-\d+\.jpg$/)) {
-                                        imageListArray.push(entry);
-                                    }
-                                } else {
-                                    if (entry.match(/-\d+\.png$/)) {
-                                        imageListArray.push(entry);
-                                    }
+                                if (entry.match(imgRegexp)) {
+                                    imageListArray.push(entry);
                                 }
                             }
                             // IOUtils.getChildren() is not guaranteed to return files in alphanumerical order
@@ -472,7 +472,7 @@ ZoteroOCR = {
                         upperLimit = maximumPagesAsHtml + 1;
                     }
                     for (let i = 1; i < upperLimit; i++) {
-                        let pagename = 'page-' + i + '.html';
+                        let pagename = basename + '-page-' + i + '.html';
                         let htmlfile = Zotero.File.pathToFile(PathUtils.join(dir, pagename));
                         let pagecontent = preamble + "<div class='ocr_page'" + parts[i] + '<script src="https://unpkg.com/hocrjs"></script>\n</body>\n</html>';
                         Zotero.File.putContents(htmlfile, pagecontent);


### PR DESCRIPTION
This PR is designed  to avoid the problem reported in #82 . Instead of a static base name for the images and image list, we can use the base name of the original PDF. This prevents conflicts when several original PDFs are stored in the same directory (mostly for some users who prefer linked files).

It also feels like a good opportunity to use file path manipulation functions systematically and remove a few manual string-based path construction instructions.