### PR TITLE
Safer folder and file names: avoid tesseract errors from Unicode characters

### DIFF
--- a/src/chrome/content/zoteroocr.js
+++ b/src/chrome/content/zoteroocr.js
@@ -208,12 +208,14 @@ Zotero.OCR = new function() {
                     pdfItem = pdfAttachments[0];
                 }
                 let pdf = pdfItem.getFilePath();
-                let base = pdf.replace(/\.pdf$/, '');
-                let basename = pdfItem.attachmentFilename.replace(/\.pdf$/, '');
+                let baseKey = pdfItem.key;
+                let baseTitle = pdfItem.getDisplayTitle();
                 let dir = OS.Path.dirname(pdf);
                 let infofile = OS.Path.join(dir, 'pdfinfo.txt');
-                let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? base : base + '.ocr';
-                // TODO filter out PDFs which have already a text layer
+                // CHECK is this the right PathUtils.filename() equivalent for Zotero6
+                let baseFilename = OS.Path.basename(pdf).replace(/\.pdf$/, '')
+                let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? baseFilename : baseFilename + '.ocr';
+                // TODO filter out PDFs which have already a text layer ?
 
                 // build the pdftoppm arguments based on hidden preferences:
                 // => will produce a PDF output with reasonable size and image quality
@@ -227,16 +229,16 @@ Zotero.OCR = new function() {
                     imageFormat = "jpg";
                     let jpegQuality = Zotero.Prefs.get("zoteroocr.jpegQuality");
                     let jpegProgressive = Zotero.Prefs.get("zoteroocr.jpegProgressive");
-                    let jpegOptimization = Zotero.Prefs.get("zoteroocr.jpegOptimization");
-                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-jpeg', '-jpegopt', 'quality=' + jpegQuality + ',progressive=' + jpegProgressive + ',optimize=' + jpegOptimization, '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, OS.Path.join(dir, basename + '-page')];
+                    let jpegOptimization = Zotero.Prefs.get("zoteroocr.jpegOptimization");                    
+                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-jpeg', '-jpegopt', 'quality=' + jpegQuality + ',progressive=' + jpegProgressive + ',optimize=' + jpegOptimization, '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
                 } else {
                     imageFormat = "png";
-                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-png', '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, OS.Path.join(dir, basename + '-page')];
+                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-png', '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
                 }
 
                 progress.updateMessage("Extracting pages...");
                 // extract images from PDF
-                let imageList = OS.Path.join(dir, basename + '-list.txt');
+                let imageList = OS.Path.join(dir, baseKey + '-list.txt');
                 let pageCount;
                 if (!(yield OS.File.exists(imageList))) {
                     let pdfinfoCmdArgs = [pdf, infofile];
@@ -246,6 +248,7 @@ Zotero.OCR = new function() {
                     try {
                         let proc1 = yield Subprocess.call({
                             command: pdfinfo,
+                            workdir: dir,
                             arguments: pdfinfoCmdArgs
                         });
 
@@ -264,6 +267,7 @@ Zotero.OCR = new function() {
                     try {
                         let proc2 = yield Subprocess.call({
                             command: pdftoppm,
+                            workdir: dir,
                             arguments: pdftoppmCmdArgs,
                             stderr: "stdout"
                         });
@@ -288,9 +292,9 @@ Zotero.OCR = new function() {
                     for (let i = 1; i <= parseInt(numPages, 10); i++) {
                         let paddedIndex = "0".repeat(numPages.length) + i;
                         if (imageFormat == "jpg") {
-                            imageListArray.push(OS.Path.join(dir, basename + '-page-' + paddedIndex.substr(-numPages.length) + '.jpg'));
+                            imageListArray.push(OS.Path.join(dir, baseKey + '-page-' + paddedIndex.substr(-numPages.length) + '.jpg'));
                         } else {
-                            imageListArray.push(OS.Path.join(dir, basename + '-page-' + paddedIndex.substr(-numPages.length) + '.png'));
+                            imageListArray.push(OS.Path.join(dir, baseKey + '-page-' + paddedIndex.substr(-numPages.length) + '.png'));
                         }
                     }
                     pageCount = imageListArray.length;
@@ -336,6 +340,7 @@ Zotero.OCR = new function() {
                 logString = log("Running " + ocrEngine + ' ' + parameters.join(' '));
                 let proc = yield Subprocess.call({
                     command: ocrEngine,
+                    workdir: dir,
                     arguments: parameters,
                     stderr: "stdout"
                 })
@@ -379,7 +384,7 @@ Zotero.OCR = new function() {
                 //if (errorLogOn) {
                     // for logs longer than 24 lines, keep only the head and tail
                     const maxLogLines = 24;
-                    errorLines = errorLog.split(/\r?\n|\r|\n/g);
+                    let errorLines = errorLog.split(/\r?\n|\r|\n/g);
                     if (errorLines.length > maxLogLines) {
                         let head = errorLines.slice(0, maxLogLines / 2).join('\n');
                         let tail = errorLines.slice(-maxLogLines / 2).join('\n');
@@ -397,7 +402,7 @@ Zotero.OCR = new function() {
                 progress.updateMessage(logString);
 
                 if (Zotero.Prefs.get("zoteroocr.outputNote")) {
-                    let contents = yield Zotero.File.getContentsAsync(ocrbase + '.txt');
+                    let contents = yield Zotero.File.getContentsAsync(OS.Path.join(dir, ocrbase + '.txt'));
                     contents = contents.replace(/(?:\r\n|\r|\n)/g, '<br />');
                     let newNote = new Zotero.Item('note');
                     newNote.setNote(contents);
@@ -407,7 +412,7 @@ Zotero.OCR = new function() {
                 }
 
                 if (Zotero.Prefs.get("zoteroocr.outputHocr")) {
-                    let contents = yield Zotero.File.getContentsAsync(ocrbase + '.hocr');
+                    let contents = yield Zotero.File.getContentsAsync(OS.Path.join(dir, ocrbase + '.hocr'));
                     // replace the absolute paths of images with relative ones
                     let escapedDir = dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                     let regexp = new RegExp(escapedDir + "/", 'g');
@@ -423,24 +428,27 @@ Zotero.OCR = new function() {
                         upperLimit = maximumPagesAsHtml + 1;
                     }
                     for (let i = 1; i < upperLimit; i++) {
-                        let pagename = basename + '-page-' + i + '.html';
-                        let htmlfile = Zotero.File.pathToFile(OS.Path.join(dir, pagename));
+                        let pagename = baseKey + '-page-' + i + '.html';
+                        let absolutePagename = OS.Path.join(dir, pagename);
+                        let htmlfile = Zotero.File.pathToFile(absolutePagename);
                         let pagecontent = preamble + "<div class='ocr_page'" + parts[i] + '<script src="https://unpkg.com/hocrjs"></script>\n</body>\n</html>';
                         Zotero.File.putContents(htmlfile, pagecontent);
                         // Zotero.Attachments.importFromFile() works in group libraries, linkFromFile() does not
                         if (Zotero.Prefs.get("zoteroocr.outputAsCopyAttachment")) {
                             yield Zotero.Attachments.importFromFile({
-                                file: OS.Path.join(dir, pagename),
+                                file: absolutePagename,
                                 contentType: "text/html",
                                 libraryID: item.libraryID,
                                 parentItemID: item.id,
+                                title: 'page-' + i + '.html'
                             });
-                            yield Zotero.File.removeIfExists(OS.Path.join(dir, pagename));
+                            yield Zotero.File.removeIfExists(absolutePagename);
                         } else {
                             yield Zotero.Attachments.linkFromFile({
-                                file: OS.Path.join(dir, pagename),
+                                file: absolutePagename,
                                 contentType: "text/html",
-                                parentItemID: item.id
+                                parentItemID: item.id,
+                                title: 'page-' + i + '.html'
                             });
                         }
                     }
@@ -449,17 +457,20 @@ Zotero.OCR = new function() {
                 // attach PDF if it is a new one
                 if (Zotero.Prefs.get("zoteroocr.outputPDF") && !(Zotero.Prefs.get("zoteroocr.overwritePDF"))) {
                     // Zotero.Attachments.importFromFile() works in group libraries, linkFromFile() does not
+                    let absolutePdfFilename = OS.Path.join(dir, ocrbase + '.pdf');
                     if (Zotero.Prefs.get("zoteroocr.outputAsCopyAttachment")) {
                         yield Zotero.Attachments.importFromFile({
-                            file: ocrbase + '.pdf',
+                            file: absolutePdfFilename,
                             libraryID: item.libraryID,
                             parentItemID: item.id,
+                            title: baseTitle + '.ocr'
                         });
-                        yield Zotero.File.removeIfExists(ocrbase + '.pdf');
+                        yield Zotero.File.removeIfExists(absolutePdfFilename);
                     } else {
                         yield Zotero.Attachments.linkFromFile({
-                            file: ocrbase + '.pdf',
-                            parentItemID: item.id
+                            file: absolutePdfFilename,
+                            parentItemID: item.id,
+                            title: baseTitle + '.ocr'
                         });
                     }
                 }

--- a/src/chrome/content/zoteroocr.js
+++ b/src/chrome/content/zoteroocr.js
@@ -212,7 +212,6 @@ Zotero.OCR = new function() {
                 let baseTitle = pdfItem.getDisplayTitle();
                 let dir = OS.Path.dirname(pdf);
                 let infofile = OS.Path.join(dir, 'pdfinfo.txt');
-                // CHECK is this the right PathUtils.filename() equivalent for Zotero6
                 let baseFilename = OS.Path.basename(pdf).replace(/\.pdf$/, '')
                 let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? baseFilename : baseFilename + '.ocr';
                 // TODO filter out PDFs which have already a text layer ?

--- a/src/zotero-ocr.js
+++ b/src/zotero-ocr.js
@@ -256,10 +256,17 @@ ZoteroOCR = {
                 }
 
                 let pdf = pdfItem.getFilePath();
-                let base = pdf.replace(/\.pdf$/, '');
-                let basename = pdfItem.attachmentFilename.replace(/\.pdf$/, '');
+                // let base = pdf.replace(/\.pdf$/, '');
+                let baseKey = pdfItem.key;
+                // FIXME this returns undefimed, why?
+                let baseTitle = Zotero.Items.get(pdfItem.parentItemID).title;
+                log(baseTitle);
                 let dir = PathUtils.parent(pdf);
-                let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? base : base + '.ocr';
+                let baseFilename = PathUtils.filename(pdf).replace(/\.pdf$/, '')
+                // TODO is the directory useful anymore? Hopefully not.
+                // let absolutePathWithKey = PathUtils.join(dir, baseKey);
+                // TODO what should ocrbasee be if we overwrite the original PDF, exactly? just the PDF filename without extension
+                let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? baseFilename : baseFilename + '.ocr';
                 // TODO filter out PDFs which have already a text layer
 
                 // build the pdftoppm arguments based on hidden preferences:
@@ -275,22 +282,24 @@ ZoteroOCR = {
                     let jpegQuality = Zotero.Prefs.get("zoteroocr.jpegQuality");
                     let jpegProgressive = Zotero.Prefs.get("zoteroocr.jpegProgressive");
                     let jpegOptimization = Zotero.Prefs.get("zoteroocr.jpegOptimization");
-                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-jpeg', '-jpegopt', 'quality=' + jpegQuality + ',progressive=' + jpegProgressive + ',optimize=' + jpegOptimization, '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, PathUtils.join(dir, basename + '-page')];
+                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-jpeg', '-jpegopt', 'quality=' + jpegQuality + ',progressive=' + jpegProgressive + ',optimize=' + jpegOptimization, '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
 
                 } else {
                     imageFormat = "png";
-                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-png', '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, PathUtils.join(dir, basename + '-page')];
+                    pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-png', '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
                 }
 
                 logString = "Extracting pages...";
                 progress.updateMessage(logString);
                 // extract images from PDF
-                let imageList = PathUtils.join(dir, basename + '-list.txt');
+                let imageList = PathUtils.join(dir, baseKey + '-list.txt');
+                // let imageList = baseKey + '-list.txt'
                 let pageCount;
                 if (!(await IOUtils.exists(imageList))) {
                     logString = log("Running " + pdftoppm + ' ' + pdftoppmCmdArgs.join(' '));
                     let proc = await Subprocess.call({
                         command: pdftoppm,
+                        workdir: dir,
                         arguments: pdftoppmCmdArgs,
                         stderr: "stdout"
                     })
@@ -329,13 +338,13 @@ ZoteroOCR = {
                         (entries) => {
                             let imgRegexp;
                             if (imageFormat == "jpg") {
-                                imgRegexp = new RegExp(basename + "-page-\\d+\\.jpg$");
+                                imgRegexp = new RegExp(baseKey + "-page-\\d+\\.jpg$");
                             } else {
-                                imgRegexp = new RegExp(basename + "-page-\\d+\\.png$");
+                                imgRegexp = new RegExp(baseKey + "-page-\\d+\\.png$");
                             }
                             for (const entry of entries) {
                                 if (entry.match(imgRegexp)) {
-                                    imageListArray.push(entry);
+                                    imageListArray.push(PathUtils.filename(entry));
                                 }
                             }
                             // IOUtils.getChildren() is not guaranteed to return files in alphanumerical order
@@ -390,6 +399,7 @@ ZoteroOCR = {
 
                 let proc = await Subprocess.call({
                     command: ocrEngine,
+                    workdir: dir,
                     arguments: parameters,
                     stderr: "stdout"
                 })
@@ -434,7 +444,7 @@ ZoteroOCR = {
                 //if (errorLogOn) {
                     // for logs longer than 24 lines, keep only the head and tail
                     const maxLogLines = 24;
-                    errorLines = errorLog.split(/\r?\n|\r|\n/g);
+                    let errorLines = errorLog.split(/\r?\n|\r|\n/g);
                     if (errorLines.length > maxLogLines) {
                         let head = errorLines.slice(0, maxLogLines / 2).join('\n');
                         let tail = errorLines.slice(-maxLogLines / 2).join('\n');
@@ -452,7 +462,7 @@ ZoteroOCR = {
                 progress.updateMessage(logString);
 
                 if (Zotero.Prefs.get("zoteroocr.outputNote")) {
-                    let contents = await Zotero.File.getContentsAsync(ocrbase + '.txt');
+                    let contents = await Zotero.File.getContentsAsync(PathUtils.join(dir, ocrbase + '.txt'));
                     contents = contents.replace(/(?:\r\n|\r|\n)/g, '<br />');
                     let newNote = new Zotero.Item('note');
                     newNote.setNote(contents);
@@ -462,7 +472,7 @@ ZoteroOCR = {
                 }
 
                 if (Zotero.Prefs.get("zoteroocr.outputHocr")) {
-                    let contents = await Zotero.File.getContentsAsync(ocrbase + '.hocr');
+                    let contents = await Zotero.File.getContentsAsync(PathUtils.join(dir, ocrbase + '.hocr'));
                     // replace the absolute paths of images with relative ones
                     let escapedDir = dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                     let regexp = new RegExp(escapedDir + "/", 'g');
@@ -478,24 +488,27 @@ ZoteroOCR = {
                         upperLimit = maximumPagesAsHtml + 1;
                     }
                     for (let i = 1; i < upperLimit; i++) {
-                        let pagename = basename + '-page-' + i + '.html';
-                        let htmlfile = Zotero.File.pathToFile(PathUtils.join(dir, pagename));
+                        let pagename = baseKey + '-page-' + i + '.html';
+                        let absolutePagename = PathUtils.join(dir, pagename);
+                        let htmlfile = Zotero.File.pathToFile(absolutePagename);
                         let pagecontent = preamble + "<div class='ocr_page'" + parts[i] + '<script src="https://unpkg.com/hocrjs"></script>\n</body>\n</html>';
                         Zotero.File.putContents(htmlfile, pagecontent);
                         // Zotero.Attachments.importFromFile() works in group libraries, linkFromFile() does not
                         if (Zotero.Prefs.get("zoteroocr.outputAsCopyAttachment")) {
                             await Zotero.Attachments.importFromFile({
-                                file: PathUtils.join(dir, pagename),
+                                file: absolutePagename,
                                 contentType: "text/html",
                                 libraryID: item.libraryID,
                                 parentItemID: item.id,
+                                title: 'page-' + i + '.html'
                             });
-                            await Zotero.File.removeIfExists(PathUtils.join(dir, pagename));
+                            await Zotero.File.removeIfExists(absolutePagename);
                         } else {
                             await Zotero.Attachments.linkFromFile({
-                                file: PathUtils.join(dir, pagename),
+                                file: absolutePagename,
                                 contentType: "text/html",
-                                parentItemID: item.id
+                                parentItemID: item.id,
+                                title: 'page-' + i + '.html'
                             });
                         }
                     }
@@ -506,25 +519,27 @@ ZoteroOCR = {
                     // Zotero.Attachments.importFromFile() works in group libraries, linkFromFile() does not
                     if (Zotero.Prefs.get("zoteroocr.outputAsCopyAttachment")) {
                         await Zotero.Attachments.importFromFile({
-                            file: ocrbase + '.pdf',
+                            file: PathUtils.join(dir, ocrbase + '.pdf'),
                             libraryID: item.libraryID,
                             parentItemID: item.id,
+                            title: 'PDF.ocr'
                         });
-                        await Zotero.File.removeIfExists(ocrbase + '.pdf');
+                        await Zotero.File.removeIfExists(PathUtils.join(dir, ocrbase + '.pdf'));
                     } else {
                         await Zotero.Attachments.linkFromFile({
-                            file: ocrbase + '.pdf',
-                            parentItemID: item.id
+                            file: PathUtils.join(dir, ocrbase + '.pdf'),
+                            parentItemID: item.id,
+                            title: 'PDF.ocr'
                         });
                     }
                 }
 
                 if (!Zotero.Prefs.get("zoteroocr.outputPNG") && imageListArray) {
                     // delete image list
-                    await Zotero.File.removeIfExists(imageList);
+                    await Zotero.File.removeIfExists(PathUtils.join(dir, imageList));
                     // delete PNGs
                     for (let imageName of imageListArray) {
-                        await Zotero.File.removeIfExists(imageName);
+                        await Zotero.File.removeIfExists(PathUtils.join(dir, imageName));
                     }
                 }
             }

--- a/src/zotero-ocr.js
+++ b/src/zotero-ocr.js
@@ -257,10 +257,11 @@ ZoteroOCR = {
 
                 let pdf = pdfItem.getFilePath();
                 let baseKey = pdfItem.key;
-                let baseTitle = Zotero.Items.get(pdfItem.parentItemID).title;
+                let baseTitle = pdfItem.getDisplayTitle();
                 let dir = PathUtils.parent(pdf);
                 let baseFilename = PathUtils.filename(pdf).replace(/\.pdf$/, '')
                 let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? baseFilename : baseFilename + '.ocr';
+                // TODO filter out PDFs which have already a text layer ?
 
                 // build the pdftoppm arguments based on hidden preferences:
                 // => will produce a PDF output with reasonable size and image quality
@@ -276,7 +277,6 @@ ZoteroOCR = {
                     let jpegProgressive = Zotero.Prefs.get("zoteroocr.jpegProgressive");
                     let jpegOptimization = Zotero.Prefs.get("zoteroocr.jpegOptimization");
                     pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-jpeg', '-jpegopt', 'quality=' + jpegQuality + ',progressive=' + jpegProgressive + ',optimize=' + jpegOptimization, '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
-
                 } else {
                     imageFormat = "png";
                     pdftoppmCmdArgs = [...pdftoppmCmdArgs, '-png', '-r', Zotero.Prefs.get("zoteroocr.outputDPI"), pdf, baseKey + '-page'];
@@ -286,7 +286,6 @@ ZoteroOCR = {
                 progress.updateMessage(logString);
                 // extract images from PDF
                 let imageList = PathUtils.join(dir, baseKey + '-list.txt');
-                // let imageList = baseKey + '-list.txt'
                 let pageCount;
                 if (!(await IOUtils.exists(imageList))) {
                     logString = log("Running " + pdftoppm + ' ' + pdftoppmCmdArgs.join(' '));
@@ -510,17 +509,18 @@ ZoteroOCR = {
                 // attach PDF if it is a new one
                 if (Zotero.Prefs.get("zoteroocr.outputPDF") && !(Zotero.Prefs.get("zoteroocr.overwritePDF"))) {
                     // Zotero.Attachments.importFromFile() works in group libraries, linkFromFile() does not
+                    let absolutePdfFilename = PathUtils.join(dir, ocrbase + '.pdf');
                     if (Zotero.Prefs.get("zoteroocr.outputAsCopyAttachment")) {
                         await Zotero.Attachments.importFromFile({
-                            file: PathUtils.join(dir, ocrbase + '.pdf'),
+                            file: absolutePdfFilename,
                             libraryID: item.libraryID,
                             parentItemID: item.id,
                             title: baseTitle + '.ocr'
                         });
-                        await Zotero.File.removeIfExists(PathUtils.join(dir, ocrbase + '.pdf'));
+                        await Zotero.File.removeIfExists(absolutePdfFilename);
                     } else {
                         await Zotero.Attachments.linkFromFile({
-                            file: PathUtils.join(dir, ocrbase + '.pdf'),
+                            file: absolutePdfFilename,
                             parentItemID: item.id,
                             title: baseTitle + '.ocr'
                         });

--- a/src/zotero-ocr.js
+++ b/src/zotero-ocr.js
@@ -256,18 +256,11 @@ ZoteroOCR = {
                 }
 
                 let pdf = pdfItem.getFilePath();
-                // let base = pdf.replace(/\.pdf$/, '');
                 let baseKey = pdfItem.key;
-                // FIXME this returns undefimed, why?
                 let baseTitle = Zotero.Items.get(pdfItem.parentItemID).title;
-                log(baseTitle);
                 let dir = PathUtils.parent(pdf);
                 let baseFilename = PathUtils.filename(pdf).replace(/\.pdf$/, '')
-                // TODO is the directory useful anymore? Hopefully not.
-                // let absolutePathWithKey = PathUtils.join(dir, baseKey);
-                // TODO what should ocrbasee be if we overwrite the original PDF, exactly? just the PDF filename without extension
                 let ocrbase = Zotero.Prefs.get("zoteroocr.overwritePDF") ? baseFilename : baseFilename + '.ocr';
-                // TODO filter out PDFs which have already a text layer
 
                 // build the pdftoppm arguments based on hidden preferences:
                 // => will produce a PDF output with reasonable size and image quality
@@ -522,14 +515,14 @@ ZoteroOCR = {
                             file: PathUtils.join(dir, ocrbase + '.pdf'),
                             libraryID: item.libraryID,
                             parentItemID: item.id,
-                            title: 'PDF.ocr'
+                            title: baseTitle + '.ocr'
                         });
                         await Zotero.File.removeIfExists(PathUtils.join(dir, ocrbase + '.pdf'));
                     } else {
                         await Zotero.Attachments.linkFromFile({
                             file: PathUtils.join(dir, ocrbase + '.pdf'),
                             parentItemID: item.id,
-                            title: 'PDF.ocr'
+                            title: baseTitle + '.ocr'
                         });
                     }
                 }


### PR DESCRIPTION
This pull request addresses issues #117 #114 and probably #113

The root problem is apparently https://github.com/tesseract-ocr/tesseract/issues/3709 : Unicode in file & folder names can cause errors in Tesseract. Zotero-OCR 0.9.4 has made the problem more frequent: filenames can also trigger the bug, whereas earlier versions were probably only sensitive to characters in the parent directory.

To fix the problem, this PR:
- uses item IDs instead of item titles for images, imagelist & other filenames;
- explicitly sets the working directory while running pdftoppm and tesseract, so that only relative paths are used.



