### PR TITLE
Improve OCR quality with PNG intermediates and optional ImageMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ The default language/script to use with Tesseract, can only be one of the instal
 The user may:
 * modify the output DPI (by default: 300)
 * modify the Tesseract Page Segmentation Mode (PSM). There are many PSM options one may want to utilize when running Tesseract (see https://tesseract-ocr.github.io/tessdoc/ImproveQuality.html)
+* modify the Tesseract OCR Engine Mode (OEM)
+* choose the intermediate image format used before OCR (PNG by default, JPEG optional)
+* adjust JPEG quality if JPEG is used for intermediate images
+* pass additional optional Tesseract command-line arguments for advanced use cases
 * choose to add the new PDFs as normal attachments or as linked files. Starting with Zotero-OCR 0.8.0, the default is normal attachments, due to some drawbacks with linked files (not possible in group libraries, unwanted files remaining when a user moves attachments to the Trash...).
+
+Advanced users may also optionally preprocess rendered page images with ImageMagick before OCR. This can improve OCR quality on difficult scans. The path to the `magick` executable can be configured in the Zotero OCR preferences. Additional optional Tesseract arguments can also be passed through the preferences UI, for example `-c preserve_interword_spaces=1`.
 
 
 ![Zotero OCR Preferences](./screenshots/Zotero-OCR-Preferences.png)

--- a/src/chrome/content/preferences.xul
+++ b/src/chrome/content/preferences.xul
@@ -33,26 +33,58 @@
             <preference id="pref-zoteroocr-output-png" name="extensions.zotero.zoteroocr.outputPNG" type="bool"/>
             <preference id="pref-zoteroocr-output-dpi" name="extensions.zotero.zoteroocr.outputDPI" type="string"/>
             <preference id="pref-zoteroocr-psmmode" name="extensions.zotero.zoteroocr.psmmode" type="string"/>
+            <preference id="pref-zoteroocr-oemmode" name="extensions.zotero.zoteroocr.oemmode" type="string"/>
+            <preference id="pref-zoteroocr-extra-args" name="extensions.zotero.zoteroocr.extraArgs" type="string"/>
             <preference id="pref-zoteroocr-output-as-copy-attachment" name="extensions.zotero.zoteroocr.outputAsCopyAttachment" type="bool"/>
+            <preference id="pref-zoteroocr-image-format" name="extensions.zotero.zoteroocr.imageFormat" type="string"/>
+            <preference id="pref-zoteroocr-jpeg-quality" name="extensions.zotero.zoteroocr.jpegQuality" type="string"/>
+            <preference id="pref-zoteroocr-magick-path" name="extensions.zotero.zoteroocr.magickPath" type="string"/>
+            <preference id="pref-zoteroocr-preprocess-images" name="extensions.zotero.zoteroocr.preprocessImages" type="bool"/>
         </preferences>
         <groupbox>
-            <caption label="OCR parameters"/>
+            <caption label="Tesseract"/>
             <label value="Full location of the tesseract executable (when empty, some standard locations are searched for it):"/>
             <textbox id="pref-zoteroocr-ocrPath-value" flex="1" preference="pref-zoteroocr-ocrPath"/>
-            <label value="Full location of the pdftoppm executable:"/>
-            <textbox id="pref-zoteroocr-pdftoppmPath-value" flex="1" preference="pref-zoteroocr-pdftoppmPath"/>
             <hbox>
                 <label value="Choose a language/script you want to use for recognition (default is eng):"/>
                 <textbox id="pref-zoteroocr-language-value" preference="pref-zoteroocr-language" width="100"/>
             </hbox>
             <hbox>
+                <label value="Tesseract Page Segmentation Mode - integer from 0 to 13 (inclusive)"/>
+                <textbox id="pref-zoteroocr-psmmode-value" preference="pref-zoteroocr-psmmode" width="70"/>
+            </hbox>
+            <hbox>
+                <label value="Tesseract OCR Engine Mode (OEM) - integer from 0 to 3 (inclusive)"/>
+                <textbox id="pref-zoteroocr-oemmode-value" preference="pref-zoteroocr-oemmode" width="70"/>
+            </hbox>
+            <hbox>
+                <label value="Additional Tesseract arguments (advanced, optional):"/>
+                <textbox id="pref-zoteroocr-extra-args-value" flex="1" preference="pref-zoteroocr-extra-args"/>
+            </hbox>
+        </groupbox>
+        <groupbox>
+            <caption label="pdftoppm"/>
+            <label value="Full location of the pdftoppm executable:"/>
+            <textbox id="pref-zoteroocr-pdftoppmPath-value" flex="1" preference="pref-zoteroocr-pdftoppmPath"/>
+            <hbox>
                 <label value="Output pdf dpi (default is 300):"/>
                 <textbox id="pref-zoteroocr-output-dpi-value" preference="pref-zoteroocr-output-dpi" width="100"/>
             </hbox>
             <hbox>
-                <label value="Tesseract Page Segmentation Mode - integer from 0 to 13 (inclusive)"/>
-                <textbox id="pref-zoteroocr-psmmode-value" preference="pref-zoteroocr-psmmode" width="70"/>
+                <label value="Intermediate image format (png or jpg):"/>
+                <textbox id="pref-zoteroocr-image-format-value" preference="pref-zoteroocr-image-format" width="70"/>
             </hbox>
+            <hbox>
+                <label value="JPEG quality (only used when image format is jpg):"/>
+                <textbox id="pref-zoteroocr-jpeg-quality-value" preference="pref-zoteroocr-jpeg-quality" width="70"/>
+            </hbox>
+        </groupbox>
+        <groupbox>
+            <caption label="ImageMagick preprocessing"/>
+            <label value="Full location of the ImageMagick executable (optional):"/>
+            <textbox id="pref-zoteroocr-magick-path-value" flex="1" preference="pref-zoteroocr-magick-path"/>
+            <checkbox preference="pref-zoteroocr-preprocess-images"
+                      label="Preprocess rendered page images with ImageMagick before OCR"/>
         </groupbox>
         <groupbox>
             <caption label="Output options"/>

--- a/src/chrome/content/zoteroocr.js
+++ b/src/chrome/content/zoteroocr.js
@@ -11,6 +11,19 @@ function log(msg) {
     return message;
 }
 
+function parseExtraArgs(input) {
+    if (!input) return [];
+    let args = [];
+    let regex = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+    let match;
+    while ((match = regex.exec(input)) !== null) {
+        let token = match[1] ?? match[2] ?? match[3] ?? '';
+        token = token.replace(/\\(["'\\])/g, '$1');
+        if (token) args.push(token);
+    }
+    return args;
+}
+
 function createZoteroProgressWindow(message, initialProgress = 0) {
     try {
         // Create a progress window using Zotero's API
@@ -162,6 +175,16 @@ Zotero.OCR = new function() {
                 return;
             }
 
+            let magick = Zotero.Prefs.get("zoteroocr.magickPath") || "";
+            if (Zotero.Prefs.get("zoteroocr.preprocessImages")) {
+                let magickPaths = ["", "/usr/local/bin/", "/usr/bin/", "/opt/homebrew/bin/", "/usr/local/homebrew/bin/", "/run/current-system/sw/bin/"];
+                magick = yield checkExternalCmd("magick", "zoteroocr.magickPath", magickPaths);
+                if (!(yield OS.File.exists(magick))) {
+                    window.alert("Image preprocessing is enabled, but no ImageMagick executable found, last check: " + magick);
+                    return;
+                }
+            }
+
             // Use the special pdfinfo variant in the zotero directory (which comes along Zotero)
             // See https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/File_I_O#Getting_special_files
             // and https://dxr.mozilla.org/mozilla-central/source/xpcom/io/nsDirectoryServiceDefs.h.
@@ -220,7 +243,7 @@ Zotero.OCR = new function() {
                 // => will produce a PDF output with reasonable size and image quality
                 // File format: JPEG by default instead of PNG
                 // JPEG quality 70/100 (pdftoppm default is 75)
-                // JPEG Hufmann tables optimization: yes (pdftoppm default is no)
+                // JPEG Huffman tables optimization: yes (pdftoppm default is no)
                 // Use progressive JPEG: yes (pdftoppm default is no)
                 let imageFormat = Zotero.Prefs.get("zoteroocr.imageFormat");
                 let pdftoppmCmdArgs = ['-progress'];
@@ -305,7 +328,56 @@ Zotero.OCR = new function() {
                     pageCount = lines.length - 1
                 }
 
-                let parameters = [imageList];
+                let processedImages = [];
+                let processedList = null;
+                let tesseractInputList = imageList;
+                if (Zotero.Prefs.get("zoteroocr.preprocessImages")) {
+                    progress.updateMessage("Preprocessing images...");
+                    processedList = OS.Path.join(dir, baseKey + '-processed-list.txt');
+                    let sourceImages = imageListArray;
+                    if (!sourceImages) {
+                        let buffer = yield Zotero.File.getContentsAsync(imageList);
+                        sourceImages = buffer.split(/\r?\n/).filter(Boolean);
+                    }
+
+                    for (let imageName of sourceImages) {
+                        let sourceImage = OS.Path.isAbsolute(imageName) ? imageName : OS.Path.join(dir, imageName);
+                        let processedImage = sourceImage.replace(/\.(jpg|png)$/i, '.processed.png');
+                        let magickArgs = [
+                            sourceImage,
+                            '-colorspace', 'Gray',
+                            '-auto-level',
+                            '-deskew', '40%',
+                            '-sharpen', '0x1',
+                            '-define', 'png:color-type=0',
+                            '-threshold', '55%',
+                            processedImage
+                        ];
+                        logString = log("Running " + magick + ' ' + magickArgs.join(' '));
+                        let procMagick = yield Subprocess.call({
+                            command: magick,
+                            workdir: dir,
+                            arguments: magickArgs,
+                            stderr: "stdout"
+                        });
+                        let magickOutput = '';
+                        let magickLine;
+                        while ((magickLine = yield procMagick.stdout.readString())) {
+                            magickOutput += magickLine;
+                            logString = log(magickLine);
+                        }
+                        let { exitCode: magickExitCode } = yield procMagick.wait();
+                        if (magickExitCode !== 0) {
+                            throw new Error("ImageMagick preprocessing failed: " + magickOutput);
+                        }
+                        processedImages.push(processedImage);
+                    }
+
+                    Zotero.File.putContents(Zotero.File.pathToFile(processedList), processedImages.join('\n'));
+                    tesseractInputList = processedList;
+                }
+
+                let parameters = [tesseractInputList];
                 parameters.push(ocrbase);
 
                 parameters.push('--psm');
@@ -319,6 +391,15 @@ Zotero.OCR = new function() {
                 }
                 parameters.push(PSMMode);
 
+                parameters.push('--oem');
+                const validOEMModes = ["0", "1", "2", "3"];
+                let OEMMode = Zotero.Prefs.get("zoteroocr.oemmode");
+                if (validOEMModes.indexOf(OEMMode) < 0) {
+                    OEMMode = "1";
+                    Zotero.Prefs.set("zoteroocr.oemmode", OEMMode);
+                }
+                parameters.push(OEMMode);
+
                 let ocrLanguage = Zotero.Prefs.get("zoteroocr.language");
                 // Convert existing instances with older or buggy defaults to English
                 if (!ocrLanguage || ocrLanguage === 'undefined') {
@@ -327,6 +408,11 @@ Zotero.OCR = new function() {
                 }
                 parameters.push('-l');
                 parameters.push(ocrLanguage);
+
+                let extraArgs = parseExtraArgs(Zotero.Prefs.get("zoteroocr.extraArgs") || "");
+                for (let arg of extraArgs) {
+                    parameters.push(arg);
+                }
                 parameters.push('txt');
                 if (Zotero.Prefs.get("zoteroocr.outputPDF")) {
                     parameters.push('pdf');
@@ -475,10 +561,17 @@ Zotero.OCR = new function() {
                 }
 
                 if (!Zotero.Prefs.get("zoteroocr.outputPNG") && imageListArray) {
-                    // delete image list
+                    // delete original image list
                     yield Zotero.File.removeIfExists(imageList);
-                    // delete PNGs
+                    // delete original images
                     for (let imageName of imageListArray) {
+                        yield Zotero.File.removeIfExists(imageName);
+                    }
+                    // delete processed image list and images
+                    if (processedList) {
+                        yield Zotero.File.removeIfExists(processedList);
+                    }
+                    for (let imageName of processedImages) {
                         yield Zotero.File.removeIfExists(imageName);
                     }
                 }

--- a/src/defaults/preferences/defaults.js
+++ b/src/defaults/preferences/defaults.js
@@ -7,11 +7,14 @@ pref("extensions.zotero.zoteroocr.outputHocr", true);
 pref("extensions.zotero.zoteroocr.outputPNG", true);
 pref("extensions.zotero.zoteroocr.maximumPagesAsHtml", "5");
 pref("extensions.zotero.zoteroocr.outputDPI", "300");
+pref("extensions.zotero.zoteroocr.oemmode", "1");
 pref("extensions.zotero.zoteroocr.psmmode", "3");
 pref("extensions.zotero.zoteroocr.outputAsCopyAttachment", true);
 // Hidden pdftoppm preferences
-pref("extensions.zotero.zoteroocr.imageFormat", "jpg");
+pref("extensions.zotero.zoteroocr.imageFormat", "png");
 pref("extensions.zotero.zoteroocr.jpegQuality", "70");
 pref("extensions.zotero.zoteroocr.jpegProgressive", "y");
 pref("extensions.zotero.zoteroocr.jpegOptimization", "y");
-
+pref("extensions.zotero.zoteroocr.magickPath", "");
+pref("extensions.zotero.zoteroocr.preprocessImages", false);
+pref("extensions.zotero.zoteroocr.extraArgs", "");

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -7,11 +7,14 @@ pref("extensions.zotero.zoteroocr.outputHocr", true);
 pref("extensions.zotero.zoteroocr.outputPNG", true);
 pref("extensions.zotero.zoteroocr.maximumPagesAsHtml", "5");
 pref("extensions.zotero.zoteroocr.outputDPI", "300");
+pref("extensions.zotero.zoteroocr.oemmode", "1");
 pref("extensions.zotero.zoteroocr.psmmode", "3");
 pref("extensions.zotero.zoteroocr.outputAsCopyAttachment", true);
 // Hidden pdftoppm preferences
-pref("extensions.zotero.zoteroocr.imageFormat", "jpg");
+pref("extensions.zotero.zoteroocr.imageFormat", "png");
 pref("extensions.zotero.zoteroocr.jpegQuality", "70");
 pref("extensions.zotero.zoteroocr.jpegProgressive", "y");
 pref("extensions.zotero.zoteroocr.jpegOptimization", "y");
-
+pref("extensions.zotero.zoteroocr.magickPath", "");
+pref("extensions.zotero.zoteroocr.preprocessImages", false);
+pref("extensions.zotero.zoteroocr.extraArgs", "");

--- a/src/prefs.xhtml
+++ b/src/prefs.xhtml
@@ -1,22 +1,47 @@
    <vbox>
         <groupbox>
-            <caption label="OCR parameters"/>
+            <caption label="Tesseract"/>
             <label value="Full location of the tesseract executable (when empty, some standard locations are searched for it):"/>
             <html:input type="text" id="pref-zoteroocr-ocrPath-value" flex="1" preference="extensions.zotero.zoteroocr.ocrPath"/>
-            <label value="Full location of the pdftoppm executable:"/>
-            <html:input type="text" id="pref-zoteroocr-pdftoppmPath-value" flex="1" preference="extensions.zotero.zoteroocr.pdftoppmPath"/>
             <hbox>
                 <label value="Choose a language/script you want to use for recognition (default is eng):"/>
                 <html:input type="text" id="pref-zoteroocr-language-value" preference="extensions.zotero.zoteroocr.language" width="100"/>
             </hbox>
             <hbox>
+                <label value="Tesseract Page Segmentation Mode - integer from 0 to 13 (inclusive)"/>
+                <html:input type="text" id="pref-zoteroocr-psmmode-value" preference="extensions.zotero.zoteroocr.psmmode" width="30"/>
+            </hbox>
+            <hbox>
+                <label value="Tesseract OCR Engine Mode (OEM) - integer from 0 to 3 (inclusive)"/>
+                <html:input type="text" id="pref-zoteroocr-oemmode-value" preference="extensions.zotero.zoteroocr.oemmode" width="30"/>
+            </hbox>
+            <hbox>
+                <label value="Additional Tesseract arguments (advanced, optional):"/>
+                <html:input type="text" id="pref-zoteroocr-extraArgs-value" flex="1" preference="extensions.zotero.zoteroocr.extraArgs"/>
+            </hbox>
+        </groupbox>
+        <groupbox>
+            <caption label="pdftoppm"/>
+            <label value="Full location of the pdftoppm executable:"/>
+            <html:input type="text" id="pref-zoteroocr-pdftoppmPath-value" flex="1" preference="extensions.zotero.zoteroocr.pdftoppmPath"/>
+            <hbox>
                 <label value="Output pdf dpi (default is 300):"/>
                 <html:input type="text" id="pref-zoteroocr-outputdpi-value" preference="extensions.zotero.zoteroocr.outputDPI" width="60"/>
             </hbox>
             <hbox>
-                <label value="Tesseract Page Segmentation Mode - integer from 0 to 13 (inclusive)"/>
-                <html:input type="text" id="pref-zoteroocr-psmmode-value" preference="extensions.zotero.zoteroocr.psmmode" width="30"/>
+                <label value="Intermediate image format (png or jpg):"/>
+                <html:input type="text" id="pref-zoteroocr-imageFormat-value" preference="extensions.zotero.zoteroocr.imageFormat" width="60"/>
             </hbox>
+            <hbox>
+                <label value="JPEG quality (only used when image format is jpg):"/>
+                <html:input type="text" id="pref-zoteroocr-jpegQuality-value" preference="extensions.zotero.zoteroocr.jpegQuality" width="60"/>
+            </hbox>
+        </groupbox>
+        <groupbox>
+            <caption label="ImageMagick preprocessing"/>
+            <label value="Full location of the ImageMagick executable (optional):"/>
+            <html:input type="text" id="pref-zoteroocr-magickPath-value" flex="1" preference="extensions.zotero.zoteroocr.magickPath"/>
+            <checkbox preference="extensions.zotero.zoteroocr.preprocessImages" label="Preprocess rendered page images with ImageMagick before OCR"/>
         </groupbox>
         <groupbox>
             <caption label="Output options"/>

--- a/src/zotero-ocr.js
+++ b/src/zotero-ocr.js
@@ -21,6 +21,19 @@ function log(msg) {
     return message;
 }
 
+function parseExtraArgs(input) {
+    if (!input) return [];
+    let args = [];
+    let regex = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+    let match;
+    while ((match = regex.exec(input)) !== null) {
+        let token = match[1] ?? match[2] ?? match[3] ?? '';
+        token = token.replace(/\\(["'\\])/g, '$1');
+        if (token) args.push(token);
+    }
+    return args;
+}
+
 function createZoteroProgressWindow(message, initialProgress = 0) {
     try {
         // Create a progress window using Zotero's API
@@ -222,6 +235,16 @@ ZoteroOCR = {
                 return;
             }
 
+            let magick = Zotero.Prefs.get("zoteroocr.magickPath") || "";
+            if (Zotero.Prefs.get("zoteroocr.preprocessImages")) {
+                let magickPaths = ["", "/usr/local/bin/", "/usr/bin/", "/opt/homebrew/bin/", "/usr/local/homebrew/bin/", "/run/current-system/sw/bin/"];
+                magick = await checkExternalCmd("magick", "zoteroocr.magickPath", magickPaths);
+                if (!(await IOUtils.exists(magick))) {
+                    window.alert("Image preprocessing is enabled, but no ImageMagick executable found, last check: " + magick);
+                    return;
+                }
+            }
+
             // Proceed with the actual selected items, process if the item is a PDF.
 
             let items = Zotero.getActiveZoteroPane().getSelectedItems();
@@ -267,7 +290,7 @@ ZoteroOCR = {
                 // => will produce a PDF output with reasonable size and image quality
                 // File format: JPEG by default instead of PNG
                 // JPEG quality 70/100 (pdftoppm default is 75)
-                // JPEG Hufmann tables optimization: yes (pdftoppm default is no)
+                // JPEG Huffman tables optimization: yes (pdftoppm default is no)
                 // Use progressive JPEG: yes (pdftoppm default is no)
                 let imageFormat = Zotero.Prefs.get("zoteroocr.imageFormat");
                 let pdftoppmCmdArgs = ['-progress'];
@@ -354,7 +377,56 @@ ZoteroOCR = {
                     pageCount = lines.length - 1
                 }
 
-                let parameters = [imageList];
+                let processedImages = [];
+                let processedList = null;
+                let tesseractInputList = imageList;
+                if (Zotero.Prefs.get("zoteroocr.preprocessImages")) {
+                    progress.updateMessage("Preprocessing images...");
+                    processedList = PathUtils.join(dir, baseKey + '-processed-list.txt');
+                    let sourceImages = imageListArray;
+                    if (!sourceImages) {
+                        let buffer = await Zotero.File.getContentsAsync(imageList);
+                        sourceImages = buffer.split(/\r?\n/).filter(Boolean);
+                    }
+
+                    for (let imageName of sourceImages) {
+                        let sourceImage = PathUtils.isAbsolute(imageName) ? imageName : PathUtils.join(dir, imageName);
+                        let processedImage = sourceImage.replace(/\.(jpg|png)$/i, '.processed.png');
+                        let magickArgs = [
+                            sourceImage,
+                            '-colorspace', 'Gray',
+                            '-auto-level',
+                            '-deskew', '40%',
+                            '-sharpen', '0x1',
+                            '-define', 'png:color-type=0',
+                            '-threshold', '55%',
+                            processedImage
+                        ];
+                        logString = log("Running " + magick + ' ' + magickArgs.join(' '));
+                        let procMagick = await Subprocess.call({
+                            command: magick,
+                            workdir: dir,
+                            arguments: magickArgs,
+                            stderr: "stdout"
+                        });
+                        let magickOutput = '';
+                        let magickLine;
+                        while ((magickLine = await procMagick.stdout.readString())) {
+                            magickOutput += magickLine;
+                            logString = log(magickLine);
+                        }
+                        let { exitCode: magickExitCode } = await procMagick.wait();
+                        if (magickExitCode !== 0) {
+                            throw new Error("ImageMagick preprocessing failed: " + magickOutput);
+                        }
+                        processedImages.push(PathUtils.filename(processedImage));
+                    }
+
+                    Zotero.File.putContents(Zotero.File.pathToFile(processedList), processedImages.join('\n'));
+                    tesseractInputList = processedList;
+                }
+
+                let parameters = [tesseractInputList];
                 parameters.push(ocrbase);
 
                 parameters.push('--psm');
@@ -368,6 +440,15 @@ ZoteroOCR = {
                 }
                 parameters.push(PSMMode);
 
+                parameters.push('--oem');
+                const validOEMModes = ["0", "1", "2", "3"];
+                let OEMMode = Zotero.Prefs.get("zoteroocr.oemmode");
+                if (validOEMModes.indexOf(OEMMode) < 0) {
+                    OEMMode = "1";
+                    Zotero.Prefs.set("zoteroocr.oemmode", OEMMode);
+                }
+                parameters.push(OEMMode);
+
                 let ocrLanguage = Zotero.Prefs.get("zoteroocr.language");
                 // Convert existing instances with older or buggy defaults to English OCR
                 if (!ocrLanguage || ocrLanguage === 'undefined') {
@@ -376,6 +457,11 @@ ZoteroOCR = {
                 }
                 parameters.push('-l');
                 parameters.push(ocrLanguage);
+
+                let extraArgs = parseExtraArgs(Zotero.Prefs.get("zoteroocr.extraArgs") || "");
+                for (let arg of extraArgs) {
+                    parameters.push(arg);
+                }
 
                 parameters.push('txt');
                 if (Zotero.Prefs.get("zoteroocr.outputPDF")) {
@@ -528,10 +614,17 @@ ZoteroOCR = {
                 }
 
                 if (!Zotero.Prefs.get("zoteroocr.outputPNG") && imageListArray) {
-                    // delete image list
-                    await Zotero.File.removeIfExists(PathUtils.join(dir, imageList));
-                    // delete PNGs
+                    // delete original image list
+                    await Zotero.File.removeIfExists(imageList);
+                    // delete original images
                     for (let imageName of imageListArray) {
+                        await Zotero.File.removeIfExists(PathUtils.join(dir, imageName));
+                    }
+                    // delete processed image list and images
+                    if (processedList) {
+                        await Zotero.File.removeIfExists(processedList);
+                    }
+                    for (let imageName of processedImages) {
                         await Zotero.File.removeIfExists(PathUtils.join(dir, imageName));
                     }
                 }


### PR DESCRIPTION
## Summary

This PR improves OCR quality for difficult PDFs by exposing more of the OCR pipeline in the preferences UI and by adding an optional preprocessing step for rendered page images.

## Motivation

The original problem was that OCR output could be readable enough for a human, but still too noisy for downstream tooling like translation tools.

This shows up when OCR text is used as input to other Zotero plugins and processing steps, for example translation workflows such as [Zotero PDF Translate]((e.g. https://github.com/windingwind/zotero-pdf-translate). In those cases, missing word boundaries, compression artefacts, and noisy OCR output can make the extracted text unreliable even when it looks superficially readable.

This PR aims to improve the quality of the OCR text at the source, so that the output is more usable not only for reading, but also as machine-consumable input for further processing.

## What this changes

### Better defaults for intermediate page images
- change the default intermediate image format from `jpg` to `png`

This avoids lossy JPEG artefacts in the page images passed to Tesseract.

### Optional preprocessing stage before OCR
- add optional preprocessing of rendered page images with ImageMagick
- allow configuring the path to the `magick` executable

When enabled, the plugin preprocesses the rendered page images before sending them to Tesseract.

### More OCR controls exposed in the UI

The settings are now grouped by pipeline stage:

#### Tesseract
- path to Tesseract
- language
- PSM
- OEM
- additional Tesseract arguments

#### pdftoppm
- path to pdftoppm
- DPI
- intermediate image format
- JPEG quality

#### ImageMagick preprocessing
- path to ImageMagick
- preprocessing toggle

#### Output options
- existing output and attachment settings

### Additional Tesseract arguments
- add an optional field for advanced extra Tesseract arguments

This makes it possible to pass options such as:

`-c preserve_interword_spaces=1`

without wrapper scripts.

## Why this helps

Previously, improving OCR quality for difficult scans required external wrapper scripts around Tesseract.

With this PR, users can improve OCR quality directly in the plugin by:
- using lossless PNG intermediates
- enabling preprocessing of rendered page images
- tuning OEM / PSM
- passing optional advanced Tesseract flags

This makes the OCR output more suitable for downstream processing, including translation and other text-based plugins.

## Notes

- JPEG support is retained for users who prefer smaller intermediate files
- ImageMagick preprocessing is optional and disabled by default
- both Zotero 7/8 and Zotero 6 codepaths are updated

## Tested

Tested locally with problematic scanned PDFs where previous OCR output contained noisy word boundaries and poor spacing.

Verified:
- context menu entry remains available
- OCR still runs normally with default settings
- PNG intermediates work
- optional ImageMagick preprocessing works
- extra Tesseract arguments are passed through
- resulting OCR output is cleaner and more usable for downstream processing

### Other options

my initial way to fix this was to rewire Tesseract to a wrapper like `$HOME/bin/tesseract-zotoro.sh` but this is a lot more brittle for the user especially when their day-job isn't software-engineering. FWIW, here is this approach:


```bash
cat bin/tesseract-zotero.sh
#!/bin/bash
set -euo pipefail

logfile="$HOME/zotero-tesseract.log"

{
  echo "============================================================"
  echo "started $0 ..."
  echo "called with args: $*"
  date
} >> "$logfile"

# --- helpers ---------------------------------------------------------------

have_cmd() {
  command -v "$1" >/dev/null 2>&1
}

pick_imagemagick() {
  if have_cmd magick; then
    echo "magick"
  elif have_cmd convert; then
    echo "convert"
  else
    echo ""
  fi
}

cleanup() {
  if [[ -n "${tmpdir:-}" && -d "${tmpdir:-}" ]]; then
    rm -rf "$tmpdir"
  fi
}
trap cleanup EXIT

args=()
skip_next=0

for arg in "$@"; do
  if [[ "$skip_next" -eq 1 ]]; then
    skip_next=0
    continue
  fi

  case "$arg" in
    --psm)
      skip_next=1
      ;;
    *)
      args+=("$arg")
      ;;
  esac
done

if [[ "${#args[@]}" -lt 4 ]]; then
  echo "unexpected args after filtering: ${args[*]}" >> "$logfile"
  exec /usr/bin/tesseract --oem 1 --psm 6 "${args[@]}"
fi

input_path="${args[0]}"
output_base="${args[1]}"

# Everything after input/output remains intact: e.g. -l deu txt pdf
rest_args=("${args[@]:2}")

tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/zotero-ocr.XXXXXX")"
processed_input="$input_path"

IM_CMD="$(pick_imagemagick)"

{
  echo "input_path=$input_path"
  echo "output_base=$output_base"
  echo "rest_args=${rest_args[*]}"
  echo "tmpdir=$tmpdir"
  echo "imagemagick=${IM_CMD:-not found}"
} >> "$logfile"

if [[ "$input_path" == *-list.txt ]] && [[ -f "$input_path" ]]; then
  if [[ -z "$IM_CMD" ]]; then
    echo "ImageMagick not found; falling back to raw input list" >> "$logfile"
  else
    new_list="$tmpdir/processed-list.txt"
    touch "$new_list"

    page=0
    while IFS= read -r img_path || [[ -n "$img_path" ]]; do
      [[ -z "$img_path" ]] && continue

      if [[ ! -f "$img_path" ]]; then
        echo "missing image from list: $img_path" >> "$logfile"
        continue
      fi

      page=$((page + 1))
      out_img="$tmpdir/page-$(printf '%04d' "$page").png"

      {
        echo "preprocessing page $page"
        echo "  src=$img_path"
        echo "  dst=$out_img"
      } >> "$logfile"

      # Conservative preprocessing aimed at improving word separation:
      # - grayscale
      # - mild contrast normalization
      # - deskew
      # - light sharpening
      # - threshold to monochrome
      #
      # Tune these if needed; deskew percentage and threshold are the main knobs.
      if [[ "$IM_CMD" == "magick" ]]; then
        magick "$img_path" \
          -colorspace Gray \
          -auto-level \
          -deskew 40% \
          -sharpen 0x1 \
          -define png:color-type=0 \
          -threshold 55% \
          "$out_img"
      else
        convert "$img_path" \
          -colorspace Gray \
          -auto-level \
          -deskew 40% \
          -sharpen 0x1 \
          -define png:color-type=0 \
          -threshold 55% \
          "$out_img"
      fi

      echo "$out_img" >> "$new_list"
    done < "$input_path"

    if [[ -s "$new_list" ]]; then
      processed_input="$new_list"
      echo "using processed list: $processed_input" >> "$logfile"
    else
      echo "processed list ended up empty; falling back to raw list" >> "$logfile"
    fi
  fi
fi


final_cmd=(
  /usr/bin/tesseract
  --oem 1
  --psm 6
  "$processed_input"
  "$output_base"
  "${rest_args[@]}"
)

{
  echo "exec: ${final_cmd[*]}"
} >> "$logfile"

exec "${final_cmd[@]}"
```